### PR TITLE
修复Simditor保存后文本颜色丢失等问题

### DIFF
--- a/src/pages/admin/components/Simditor.vue
+++ b/src/pages/admin/components/Simditor.vue
@@ -45,10 +45,10 @@
         }
       })
       this.editor.on('valuechanged', (e, src) => {
-        this.currentValue = this.editor.getValue()
+        this.currentValue = e.target.body[0].innerHTML
       })
       this.editor.on('decorate', (e, src) => {
-        this.currentValue = this.editor.getValue()
+        this.currentValue = e.target.body[0].innerHTML
       })
 
       this.editor.setValue(this.value)


### PR DESCRIPTION
修复Simditor保存后文本颜色丢失等问题，原因是其自带的getValue()方法获取不到完整html内容

效果如图：
![image](https://user-images.githubusercontent.com/2792725/101861853-063ce580-3bac-11eb-8bc0-8a95353bf82e.png)
